### PR TITLE
Add learning memory and improved web search

### DIFF
--- a/backend/features/web_search.py
+++ b/backend/features/web_search.py
@@ -3,9 +3,40 @@ from bs4 import BeautifulSoup
 from typing import Optional
 
 def web_search(query: str) -> str:
+    """Return a few web snippets for the given query."""
     headers = {"User-Agent": "Mozilla/5.0"}
 
-    # 1. Try Bing HTML scrape
+    # 1. DuckDuckGo search with snippets
+    try:
+        res = requests.get(
+            "https://duckduckgo.com/html/",
+            params={"q": query},
+            headers=headers,
+            timeout=5,
+        )
+        soup = BeautifulSoup(res.text, "html.parser")
+        results = soup.find_all("div", class_="result", limit=3)
+        snippets: list[str] = []
+        for r in results:
+            title = r.find("a", class_="result__a")
+            snippet = (
+                r.find("a", class_="result__snippet")
+                or r.find("div", class_="result__snippet")
+                or r.find("span", class_="result__snippet")
+            )
+            text_parts = []
+            if title and title.get_text():
+                text_parts.append(title.get_text(" ", strip=True))
+            if snippet and snippet.get_text():
+                text_parts.append(snippet.get_text(" ", strip=True))
+            if text_parts:
+                snippets.append(" - ".join(text_parts))
+        if snippets:
+            return "\n".join(snippets)
+    except Exception as e:
+        print(f"[DuckDuckGo Error] {e}")
+
+    # 2. Bing fallback
     try:
         bing_url = f"https://www.bing.com/search?q={query}"
         res = requests.get(bing_url, headers=headers, timeout=5)
@@ -14,24 +45,18 @@ def web_search(query: str) -> str:
         links: list[str] = []
         for r in results:
             a_tag: Optional[BeautifulSoup] = r.find("a")
+            snippet = r.find("p")
+            text_parts = []
             if a_tag and a_tag.get_text():
-                links.append(a_tag.get_text())
+                text_parts.append(a_tag.get_text(" ", strip=True))
+            if snippet and snippet.get_text():
+                text_parts.append(snippet.get_text(" ", strip=True))
+            if text_parts:
+                links.append(" - ".join(text_parts))
         if links:
             return "\n".join(links)
     except Exception as e:
         print(f"[Bing Error] {e}")
-
-    # 2. DuckDuckGo fallback (NEW METHOD - old html.duckduckgo.com is unstable)
-    try:
-        ddg_url = f"https://lite.duckduckgo.com/lite/?q={query}"
-        res = requests.get(ddg_url, headers=headers, timeout=5)
-        soup = BeautifulSoup(res.text, "html.parser")
-        links = soup.find_all("a", limit=3)
-        texts = [a.get_text() for a in links if a and a.get_text()]
-        if texts:
-            return "\n".join(texts)
-    except Exception as e:
-        print(f"[DuckDuckGo Error] {e}")
 
     # 3. Ollama fallback
     try:

--- a/backend/main.py
+++ b/backend/main.py
@@ -16,7 +16,11 @@ def main():
     online_mode = True  # Set to False to disable web search
 
     while True:
-        prompt = input("🧠 You: ").strip()
+        try:
+            prompt = input("🧠 You: ").strip()
+        except (EOFError, KeyboardInterrupt):
+            print("\n👋 JARVIS shutting down.")
+            break
         if prompt.lower() == "exit":
             print("👋 JARVIS shutting down.")
             break


### PR DESCRIPTION
## Summary
- refine `KnowledgeBase` to track when new facts or QA are stored
- enhance DuckDuckGo search to fetch result snippets
- upgrade `AIBrain` to enrich prompts with snippets, reuse prior answers, and mark when memory is used
- make CLI loop handle Ctrl+C

## Testing
- `python -m py_compile backend/features/ai_brain.py backend/features/knowledge.py backend/features/web_search.py backend/main.py`
- `python backend/main.py <<'EOF'
exit
EOF`

------
https://chatgpt.com/codex/tasks/task_e_68538936acb4832b92c9acfa3e92fe85