### PR TITLE
Enhance JARVIS knowledge management

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -39,5 +39,15 @@ def main():
 
         print(f"🤖 JARVIS: {response}")
 
+        try:
+            feedback = input("Feedback (✅ correct/❌ wrong)? ").strip()
+        except (EOFError, KeyboardInterrupt):
+            feedback = ""
+        if feedback == "❌ wrong":
+            correction = input("Please provide the correct answer: ").strip()
+            if correction:
+                brain.knowledge.update_answer(prompt, correction, confidence=1.5)
+                print("Correction stored.\n")
+
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- add token counting and confidence tracking in the knowledge base
- allow self‑healing updates and clean out short entries
- improve fact conflict resolution and fallback summary generation
- prompt user feedback after each answer and store corrections

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685391d44e24832b8f0b7a859fa43c3a